### PR TITLE
[BOOST-4779]: fix broken v1 links

### DIFF
--- a/v1/boost-api/claim-a-boost.mdx
+++ b/v1/boost-api/claim-a-boost.mdx
@@ -12,7 +12,7 @@ Prerequisites for claiming a boost include:
 
 ## Getting a boost completion signature
 
-Before submitting the claim transaction, a signature verifying the completion of the specific boost action by the end user must be requested from [the /boosts/get-signature endpoint](/api-reference/boosts/signature).
+Before submitting the claim transaction, a signature verifying the completion of the specific boost action by the end user must be requested from [the /boosts/get-signature endpoint](/v1/api-reference/boosts/signature).
 
 ```typescript
 const getSignatureResponse = await fetch('https://api.boost.xyz/boosts/get-signature', {
@@ -89,5 +89,5 @@ const signatureObjects = await getSignatureBatchResponse.json();
 [//]: # (TODO: update get-signature-batch link once API reference is updated)
 <Tip>
     Note that individual signature request failures fail silently for [the /boosts/get-signature-batch endpoint](https://api.boost.xyz/docs#tag/boosts/paths/\~1boosts\~1get-signature-batch/post), resulting in the failing signature requests being omitted from the response.
-    To get error information on a specific signature request failure, use the singular [/boosts/get-signature endpoint](/api-reference/boosts/signature).
+    To get error information on a specific signature request failure, use the singular [/boosts/get-signature endpoint](/v1/api-reference/boosts/signature).
 </Tip>

--- a/v1/boost-api/create-a-boost.mdx
+++ b/v1/boost-api/create-a-boost.mdx
@@ -21,7 +21,7 @@ All of the above data is [submitted to the POST /boosts endpoint](/boost-api/cre
 
 Each action to be boosted consists of a **project** (e.g. Zora) and a **task** (e.g. "mint" or "create"), along with a **network** for the task. Some actions require specific [action parameter](https://github.com/rabbitholegg/questdk/blob/main/src/actions/types.ts) values (e.g. contract address is required for the "mint" action), while other actions can be boosted with or without specific action parameters.
 
-The ID values of projects and tasks approved for the Boost Protocol can be queried using the [/manager/projects endpoint](/api-reference/manager/projects):
+The ID values of projects and tasks approved for the Boost Protocol can be queried using the [/manager/projects endpoint](/v1/api-reference/manager/projects):
 
 ```typescript
 const projectsResult = await fetch('https://api.boost.xyz/manager/projects');
@@ -60,7 +60,7 @@ Each boost requires an individual reward amount of any ERC20 token as well as a 
 
 ### Getting an individual reward amount estimate (optional)
 
-Once the reward token and chain have been specified by the end user, your application can optionally query the [/manager/reward-estimate endpoint](/api-reference/manager/reward-estimates) for a set of recommended individual reward amounts.
+Once the reward token and chain have been specified by the end user, your application can optionally query the [/manager/reward-estimate endpoint](/v1/api-reference/manager/reward-estimates) for a set of recommended individual reward amounts.
 
 ```typescript
 const queryParams = new URLSearchParams({
@@ -83,7 +83,7 @@ The three individual reward estimates returned, `low`, `mid`, and `high`, are ba
 
 ### Getting a mint reward amount estimate (optional)
 
-For boosted mints specifically, the [/manager/mint-reward-estimate endpoint](/api-reference/manager/mint-reward-estimates) provides a more specific reward amount estimate, which takes into account project fees and other mint-specific costs.
+For boosted mints specifically, the [/manager/mint-reward-estimate endpoint](/v1/api-reference/manager/mint-reward-estimates) provides a more specific reward amount estimate, which takes into account project fees and other mint-specific costs.
 
 ```typescript
 const queryParams = new URLSearchParams({
@@ -121,7 +121,7 @@ Ultimately, any participant limit value up to the maximum participant value is v
 
 ## Submitting the create boost request
 
-After querying and selecting all the required values, the next step is to submit everything to the [create boost endpoint](/api-reference/boosts/create-boost):
+After querying and selecting all the required values, the next step is to submit everything to the [create boost endpoint](/v1/api-reference/boosts/create-boost):
 
 ```typescript
 const createBoostResponse = await fetch('https://api.boost.xyz/boosts', {
@@ -160,7 +160,7 @@ The final step is to send a transaction to the blockchain of the chosen boost ac
 Boosts are created from the BoostFactory contract (still named "QuestFactory" on chain for now). This transaction also requires the ABI file for the boost factory contract, which can be found [here](https://github.com/rabbitholegg/questdk/blob/main/src/abi/quest-factory.ts).
 
 <Tip>
-    Note that for the transaction submission, the reward amount is an integer value of the wei-equivalent denomination of the reward token, so for an individual reward of 1 $DEGEN for example, which uses 18 decimals, the `rewardAmount` would be `1000000000000000000`. These values can also be found under `reward.amount` and `reward.decimals` in the response body from the [create boost endpoint](/api-reference/boosts/create-boost).
+    Note that for the transaction submission, the reward amount is an integer value of the wei-equivalent denomination of the reward token, so for an individual reward of 1 $DEGEN for example, which uses 18 decimals, the `rewardAmount` would be `1000000000000000000`. These values can also be found under `reward.amount` and `reward.decimals` in the response body from the [create boost endpoint](/v1/api-reference/boosts/create-boost).
 </Tip>
 
 ```typescript
@@ -210,4 +210,4 @@ async function deployBoost(
 }
 ```
 
-Once the above transaction succeeds, the boost has been created and will appear on all relevant Boost client apps! Use the Boost ID value from the [create boost response](/api-reference/boosts/create-boost) to lookup the new boost on [boost.xyz](https://boost.xyz) or through the [boost details endpoint](/api-reference/boosts/boost-details).
+Once the above transaction succeeds, the boost has been created and will appear on all relevant Boost client apps! Use the Boost ID value from the [create boost response](/v1/api-reference/boosts/create-boost) to lookup the new boost on [boost.xyz](https://boost.xyz) or through the [boost details endpoint](/v1/api-reference/boosts/boost-details).

--- a/v1/boost-api/fetch-boosts.mdx
+++ b/v1/boost-api/fetch-boosts.mdx
@@ -5,7 +5,7 @@ description: How to query all Boosts with various filters
 
 ## Querying boosts by creator address
 
-To fetch all Boosts created by a given address, use the [GET /boosts endpoint](/api-reference/boosts/boosts) with the `creatorAddresses` query parameter:
+To fetch all Boosts created by a given address, use the [GET /boosts endpoint](/v1/api-reference/boosts/boosts) with the `creatorAddresses` query parameter:
 
 ```typescript
 const creatorFilteredBoostsResponse = await fetch(
@@ -17,7 +17,7 @@ const { boosts } = await creatorFilteredBoostsResponse.json();
 
 ## Querying boosts by project
 
-To query all boosts for a specific project, use the [GET /boosts endpoint](/api-reference/boosts/boosts) with the `projectIds` query parameter. Project ID values can be queried from the [GET /manager/projects](/api-reference/manager/projects) endpoint, detailed on the [Create a Boost page](/boost-api/create-a-boost#querying-approved-projects-and-tasks).
+To query all boosts for a specific project, use the [GET /boosts endpoint](/v1/api-reference/boosts/boosts) with the `projectIds` query parameter. Project ID values can be queried from the [GET /manager/projects](/v1/api-reference/manager/projects) endpoint, detailed on the [Create a Boost page](/boost-api/create-a-boost#querying-approved-projects-and-tasks).
 
 The following example queries all Aerodrome and Velodrome boosts created by a set of addresses:
 
@@ -46,7 +46,7 @@ const { boosts } = await boostsByProjectResponse.json();
 
 ## Querying boosts by reward network and token
 
-Boosts can be filtered by reward network and by specific reward tokens using the [GET /boosts endpoint](/api-reference/boosts/boosts). The Boost API uses chain IDs to reference networks, which can be viewed on [ChainList](https://chainlist.org/) or found in the tasks array of the [GET /manager/projects](/api-reference/manager/projects) response.
+Boosts can be filtered by reward network and by specific reward tokens using the [GET /boosts endpoint](/v1/api-reference/boosts/boosts). The Boost API uses chain IDs to reference networks, which can be viewed on [ChainList](https://chainlist.org/) or found in the tasks array of the [GET /manager/projects](/v1/api-reference/manager/projects) response.
 
 <Tip>
     Note that if rewardTokenAddresses is included, the rewardTokenChainIds array must be included as a matching array of chain IDs, one for each rewardTokenAddress in the same order
@@ -76,7 +76,7 @@ const { boosts: boostsByToken } = await boostsByRewardToken.json();
 
 ## Querying boosts by action network
 
-To only query boosts with actions on a specific network or set of networks, query the [GET /boosts endpoint](/api-reference/boosts/boosts) using the `actionChainIds` query param, which again can be viewed on [ChainList](https://chainlist.org/) or found in the tasks array of the [GET /manager/projects](/api-reference/manager/projects) response.
+To only query boosts with actions on a specific network or set of networks, query the [GET /boosts endpoint](/v1/api-reference/boosts/boosts) using the `actionChainIds` query param, which again can be viewed on [ChainList](https://chainlist.org/) or found in the tasks array of the [GET /manager/projects](/v1/api-reference/manager/projects) response.
 
 ```typescript
 // query by action network
@@ -92,7 +92,7 @@ const { boosts } = await boostsByActionNetwork.json();
 
 ## Querying details for a specific boost
 
-To query detailed information about a specific boost, including metadata about the boosted action such as the image URL for an boosted NFT mint, as well as current boost completion stats like the list of participating addresses that have claimed the boost, use the [boost details endpoint](/api-reference/boosts/boost-details):
+To query detailed information about a specific boost, including metadata about the boosted action such as the image URL for an boosted NFT mint, as well as current boost completion stats like the list of participating addresses that have claimed the boost, use the [boost details endpoint](/v1/api-reference/boosts/boost-details):
 
 ```typescript
 const boostId = 'b5657a78-682d-41ee-984d-dd4729548a63'; // can be any valid boost ID

--- a/v1/boost-api/sign-in-to-boost.mdx
+++ b/v1/boost-api/sign-in-to-boost.mdx
@@ -3,11 +3,11 @@ title: 'Sign in to Boost'
 description: How to sign in to Boost using Sign-In with Ethereum
 ---
 
-An authorization token from the Boost API is required for certain protected routes, such as the [create boost endpoint](/api-reference/boosts/create-boost). This can be acquired with an [ERC-4361 SIWE message](https://eips.ethereum.org/EIPS/eip-4361) and signature from the end user, posted to the [/auth/login](/api-reference/auth/login) endpoint.
+An authorization token from the Boost API is required for certain protected routes, such as the [create boost endpoint](/v1/api-reference/boosts/create-boost). This can be acquired with an [ERC-4361 SIWE message](https://eips.ethereum.org/EIPS/eip-4361) and signature from the end user, posted to the [/auth/login](/v1/api-reference/auth/login) endpoint.
 
 ## Generating a SIWE message
 
-While any properly formatted SIWE message with the statement `'Sign in with Ethereum.'` and a nonce value from the [/auth/nonce](/api-reference/auth/nonce) endpoint should suffice, we recommend [the siwe library](https://www.npmjs.com/package/siwe) for JavaScript applications, to ensure all required fields are present.
+While any properly formatted SIWE message with the statement `'Sign in with Ethereum.'` and a nonce value from the [/auth/nonce](/v1/api-reference/auth/nonce) endpoint should suffice, we recommend [the siwe library](https://www.npmjs.com/package/siwe) for JavaScript applications, to ensure all required fields are present.
 
 Here is an example of SIWE message generation using [the siwe library](https://www.npmjs.com/package/siwe):
 
@@ -33,7 +33,7 @@ const formattedSiweMessage = siweMessage.prepareMessage();
 
 ## Getting an access token
 
-After generating the SIWE message and requesting a signature of the message from the end user's wallet client, send the message and signature in a POST request to the [/auth/login endpoint](/api-reference/auth/login).
+After generating the SIWE message and requesting a signature of the message from the end user's wallet client, send the message and signature in a POST request to the [/auth/login endpoint](/v1/api-reference/auth/login).
 
 <Tip>
     Note that the `origin` and `user-agent` headers are mandatory, though they are usually included automatically by the browser.
@@ -59,7 +59,7 @@ const { accessToken, refreshToken } = await loginResult.json();
 A successful response will return a body with an `accessToken` and a `refreshToken`:
 
 * The `accessToken` should be passed as the authorization header value for protected routes.
-* The `refreshToken` can be stored to allow for re-authentication without another message signature when the `accessToken` expires using the [/auth/refresh](/api-reference/auth/refresh) endpoint, which returns a new access token for the given refresh token.
+* The `refreshToken` can be stored to allow for re-authentication without another message signature when the `accessToken` expires using the [/auth/refresh](/v1/api-reference/auth/refresh) endpoint, which returns a new access token for the given refresh token.
 
 ## Getting a refreshed access token
 

--- a/v1/overview/boost-manager.mdx
+++ b/v1/overview/boost-manager.mdx
@@ -16,7 +16,7 @@ Key features of the Boost Manager app include:
 <Card
   title="How to Deploy a Boost"
   icon="bolt"
-  href="/user-guides/how-to-deploy-a-boost"
+  href="/v1/user-guides/how-to-deploy-a-boost"
 >
   Read the step-by-step guide on how to deploy a boost
 </Card>

--- a/v1/overview/boost-sdk.mdx
+++ b/v1/overview/boost-sdk.mdx
@@ -18,7 +18,7 @@ Embedding boosts into your native application is an easy way to boost the user e
 <Card
     title="Boost API Docs"
     icon="file-lines"
-    href="/boost-api/sign-in-to-boost"
+    href="/v1/boost-api/sign-in-to-boost"
 >
     Learn more about the Boost Public API and how to implement it
 </Card>

--- a/v1/overview/how-it-works.mdx
+++ b/v1/overview/how-it-works.mdx
@@ -4,7 +4,7 @@ title: "How It Works"
 
 Boost is a permissionless protocol that anyone can access and build on to deploy incentive offers.
 
-There are several different ways to interact with the protocol depending on [your role](/overview/boost-protocol#key-contributors) in the ecosystem. To understand how it works, it’s important to get familiar with the core components that make up the Boost stack:
+There are several different ways to interact with the protocol depending on [your role](boost-protocol#key-contributors) in the ecosystem. To understand how it works, it’s important to get familiar with the core components that make up the Boost stack:
 
 <Frame caption="Boost Ecosystem Overview">
   <img
@@ -26,19 +26,19 @@ Read about each of the above core components:
   <Card
     title="Boost Protocol"
     icon="dice-d6"
-    href="/overview/boost-protocol"
+    href="boost-protocol"
   ></Card>
   <Card
     title="Boost Manager"
     icon="clipboard"
-    href="/overview/boost-manager"
+    href="boost-manager"
   ></Card>
   <Card
     title="Boost Clients"
     icon="desktop"
-    href="/overview/boost-clients"
+    href="boost-clients"
   ></Card>
-  <Card title="Boost SDK" icon="code" href="/overview/boost-sdk"></Card>
+  <Card title="Boost SDK" icon="code" href="boost-sdk"></Card>
 </CardGroup>
 
 Boost Studios is currently the main contributor to the protocol by building Boost Client apps and providing Boost Manager services to other protocols. However, all these components are accessible to anyone.

--- a/v1/overview/introduction.mdx
+++ b/v1/overview/introduction.mdx
@@ -12,10 +12,10 @@ Boost is a distributed incentives network where any wallet can deploy incentive 
 If you are new to the Boost ecosystem, learn what exactly a Boost is and how everything works.
 
 <CardGroup cols={2}>
-  <Card title="What is a Boost?" icon="rocket" href="/overview/what-is-a-boost">
+  <Card title="What is a Boost?" icon="rocket" href="what-is-a-boost">
     Learn what a Boost is
   </Card>
-  <Card title="How It Works" icon="lightbulb" href="/overview/how-it-works">
+  <Card title="How It Works" icon="lightbulb" href="how-it-works">
     Learn how the Boost ecosystem works
   </Card>
 </CardGroup>
@@ -24,7 +24,7 @@ If you are new to the Boost ecosystem, learn what exactly a Boost is and how eve
 
 If you are a crypto user looking to earn on Boost, learn more about Boost App, the primary frontend client to discover and receive incentive offers, as well as other Boost clients.
 
-<Card title="Boost App" icon="star" href="/overview/boost-clients">
+<Card title="Boost App" icon="star" href="boost-clients">
   Introduction to the Boost App and Boost Clients
 </Card>
 
@@ -35,7 +35,7 @@ If your project is already supported on Boost Protocol and you are looking to de
 <Card
   title="How to Deploy a Boost"
   icon="bolt"
-  href="/user-guides/how-to-deploy-a-boost"
+  href="/v1/user-guides/how-to-deploy-a-boost"
 >
   Learn how to deploy a Boost for your project
 </Card>
@@ -45,13 +45,13 @@ If your project is already supported on Boost Protocol and you are looking to de
 If you are a developer and interested in building on Boost Protocol, start by checking out the overview of the Boost SDK and API, or jump right into testing out and reading about the Boost API.
 
 <CardGroup cols={2}>
-  <Card title="Boost SDK Overview" icon="code" href="/overview/boost-sdk">
+  <Card title="Boost SDK Overview" icon="code" href="boost-sdk">
     Read about the Boost developer ecosystem
   </Card>
   <Card
     title="Boost API Docs"
     icon="file-lines"
-    href="/boost-api/sign-in-to-boost"
+    href="/v1/boost-api/sign-in-to-boost"
   >
     See code examples and reference documentation for the API
   </Card>
@@ -64,7 +64,7 @@ If you're a rollup looking to integrate Boost on your network, learn how to depl
 <Card
   title="Rollup Integration Guide"
   icon="network-wired"
-  href="/user-guides/rollup-integration"
+  href="/v1/user-guides/rollup-integration"
 >
   Learn how to integrate Boost Protocol for Rollups
 </Card>

--- a/v1/user-guides/how-to-deploy-a-boost.mdx
+++ b/v1/user-guides/how-to-deploy-a-boost.mdx
@@ -99,7 +99,7 @@ To incentivize your target recipients to transact, you must select the ERC20 tok
   onchain action is set on in step 1.
 </Tip>
 
-After selecting the network, pick the token from the dropdown menu for rewarding users. This menu displays only [whitelisted tokens](/user-guides/how-to-whitelist-a-token) approved for use in Boost.
+After selecting the network, pick the token from the dropdown menu for rewarding users. This menu displays only [whitelisted tokens](how-to-whitelist-a-token) approved for use in Boost.
 
 <img
   src="/assets/manager-reward.png"
@@ -139,7 +139,7 @@ You can choose to deploy a boost immediately or you can schedule it at an exact 
 
 ## Deploy the Smart Contract
 
-Review all the boost details to ensure the require action, target audience and reward amount is correct. To deploy the boost, you will need to deposit the total reward funds into the smart contract, plus the [Protocol Fee](/protocol-concepts/protocol-fees). Deploying a boost requires two contract interactions: an approval of tokens and boost deployment.
+Review all the boost details to ensure the require action, target audience and reward amount is correct. To deploy the boost, you will need to deposit the total reward funds into the smart contract, plus the [Protocol Fee](/v1/protocol-concepts/protocol-fees). Deploying a boost requires two contract interactions: an approval of tokens and boost deployment.
 
 <Tip>
   Note that if you close your window, you will need to start the boost creation
@@ -195,15 +195,15 @@ Once clicking Withdraw, a confirmation will appear showing the breakdown of how 
     </Accordion>
 
     <Accordion title="What rewards can I distribute on Boost?">
-        Only whitelisted ERC20 tokens can be used as rewards on Boost at this time. For information on the whitelist process, see our [How to Add a Token to the Whitelist](/user-guides/how-to-whitelist-a-token) guide. We'll be adding support for ERC1155 and onchain points soon.
+        Only whitelisted ERC20 tokens can be used as rewards on Boost at this time. For information on the whitelist process, see our [How to Add a Token to the Whitelist](how-to-whitelist-a-token) guide. We'll be adding support for ERC1155 and onchain points soon.
     </Accordion>
 
     <Accordion title="What are the fees or costs of deploying a boost?">
-        Boost takes a 10% fee, which is split onchain with the Boost Guild, a high quality group of contributors, and the affiliate that drives the Boost, aligning incentives between all parties. Learn more about the [Protocol Fees](/protocol-concepts/protocol-fees).
+        Boost takes a 10% fee, which is split onchain with the Boost Guild, a high quality group of contributors, and the affiliate that drives the Boost, aligning incentives between all parties. Learn more about the [Protocol Fees](/v1/protocol-concepts/protocol-fees).
     </Accordion>
 
     <Accordion title="Where does the boost appear once it deploys?">
-        When the boost is deployed, it appears on the ecosystem of Boost Client apps such as Boost Inbox. Learn more about [Boost Client](/overview/boost-clients) apps.
+        When the boost is deployed, it appears on the ecosystem of Boost Client apps such as Boost Inbox. Learn more about [Boost Client](/v1/overview/boost-clients) apps.
     </Accordion>
 
     <Accordion title="Can I cancel or pause a boost I deployed?">


### PR DESCRIPTION
After the recent changes to the docs, some of the links broke after we added versioning.

All v1 links needed to be prefixed as such.

`/api-reference/boosts/signature` --> `/v1/api-reference/boosts/signature`