### PR TITLE
[BOOST-4801] add section on targetting specific chains to quickstart guide

### DIFF
--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -117,6 +117,4 @@ The SDK uses the following process to determine which chain to interact with:
 2. If no address is found for the given chainId, it falls back to using the address for the connected account's chain.
 3. If that also fails, it uses the address for the default chain set in the SDK config. 
 
-This flexible approach ensures that your operations target the intended network while providing fallback options for broader compatibility.
-
 > Note: Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a ChainNotConfigured error.

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -115,7 +115,7 @@ The SDK uses the following process to determine which chain to interact with:
 
 1. It first attempts to use the contract address associated with the specified chainId passed in the params.
 2. If no address is found for the given chainId, it falls back to using the address for the connected account's chain.
-3. If that also fails, it uses the default chain set in the SDK config. 
+3. If that also fails, it uses the address for the default chain set in the SDK config. 
 
 This flexible approach ensures that your operations target the intended network while providing fallback options for broader compatibility.
 

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -103,20 +103,21 @@ import { simpleAllowListAbi } from '@boostxyz/sdk/AllowLists/SimpleAllowList'
 
 ## Targeting Specific Chains
 
-The Boost SDK allows you to interact with Boost protocol across different chains. You can specify which chain you want to target by including a `chainId` in the params object of your method calls.
+The Boost SDK allows you to interact with the `BoostCore` and `BoostRegistry` contracts across different chains. You can specify which chain you want to target by including a `chainId` in the params object of your method calls.
 
 ```ts
 // Target a boost with id of 3 on Base mainnet (chainId: 8453)
 const boost = await core.getBoost(3n, { chainId: 8453 })
 ```
-<Note>
-  Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a `ChainNotConfigured` error.
-</Note>
 
-By specifying the chainId in the params, you ensure that the SDK targets the correct contracts for the specific network you are targetting.
+<Warning>
+  Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a `ChainNotConfigured` error.
+</Warning>
+
+By specifying the `chainId` in the params, you ensure that the SDK targets the correct contracts for the specific network you are targetting.
 
 The SDK uses the following process to determine which chain to interact with:
 
-1. It first attempts to use the contract address associated with the specified chainId passed in the params.
+1. It first attempts to use the contract address associated with the specified `chainId` passed in the params.
 2. If no address is found for the given chainId, it falls back to using the address for the connected account's chain.
-3. If that also fails, it uses the address for the default chain set in the SDK config. 
+3. If that also fails, it uses the address for the default chain set in the SDK config.

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -111,7 +111,7 @@ const boost = await core.getBoost(3n, { chainId: 8453 })
 ```
 
 <Warning>
-  Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a `ChainNotConfigured` error.
+  Always ensure that the protocol is deployed on the chain you're targeting. Specifying a `chainId` for a network where the protocol isn't deployed could result in degraded UX if, in the browser, the SDK attempts to switch chains to its default network and there's no supporting chain configuration in your `Wagmi/Viem` client.
 </Warning>
 
 By specifying the `chainId` in the params, you ensure that the SDK targets the correct contracts for the specific network you are targetting.

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -100,3 +100,23 @@ if(boost.allowList instanceof SimpleDenyList) {
 const abi = boost.allowList.abi
 import { simpleAllowListAbi } from '@boostxyz/sdk/AllowLists/SimpleAllowList'
 ```
+
+## Targeting Specific Chains
+
+The Boost SDK allows you to interact with Boost protocol across different chains. You can specify which chain you want to target by including a `chainId` in the params object of your method calls.
+
+```ts
+// Target a boost on Base mainnet (chainId: 8453)
+const boost = await core.getBoost({ chainId: 8453 })
+```
+By specifying the chainId in the params, you ensure that the SDK targets the correct contracts for the specific network you are targetting.
+
+The SDK uses the following process to determine which chain to interact with:
+
+1. It first attempts to use the contract address associated with the specified chainId passed in the params.
+2. If no address is found for the given chainId, it falls back to using the address for the connected account's chain.
+3. If that also fails, it uses the default chain set in the SDK config. 
+
+This flexible approach ensures that your operations target the intended network while providing fallback options for broader compatibility.
+
+> Note: Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in an error.

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -119,4 +119,4 @@ The SDK uses the following process to determine which chain to interact with:
 
 This flexible approach ensures that your operations target the intended network while providing fallback options for broader compatibility.
 
-> Note: Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in an error.
+> Note: Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a ChainNotConfigured error.

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -106,8 +106,8 @@ import { simpleAllowListAbi } from '@boostxyz/sdk/AllowLists/SimpleAllowList'
 The Boost SDK allows you to interact with Boost protocol across different chains. You can specify which chain you want to target by including a `chainId` in the params object of your method calls.
 
 ```ts
-// Target a boost on Base mainnet (chainId: 8453)
-const boost = await core.getBoost({ chainId: 8453 })
+// Target a boost with id of 3 on Base mainnet (chainId: 8453)
+const boost = await core.getBoost(3n, { chainId: 8453 })
 ```
 By specifying the chainId in the params, you ensure that the SDK targets the correct contracts for the specific network you are targetting.
 

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -109,6 +109,10 @@ The Boost SDK allows you to interact with Boost protocol across different chains
 // Target a boost with id of 3 on Base mainnet (chainId: 8453)
 const boost = await core.getBoost(3n, { chainId: 8453 })
 ```
+<Note>
+  Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a `ChainNotConfigured` error.
+</Note>
+
 By specifying the chainId in the params, you ensure that the SDK targets the correct contracts for the specific network you are targetting.
 
 The SDK uses the following process to determine which chain to interact with:
@@ -116,5 +120,3 @@ The SDK uses the following process to determine which chain to interact with:
 1. It first attempts to use the contract address associated with the specified chainId passed in the params.
 2. If no address is found for the given chainId, it falls back to using the address for the connected account's chain.
 3. If that also fails, it uses the address for the default chain set in the SDK config. 
-
-> Note: Always ensure that the protocol is deployed on the chain you're targeting. Specifying a chainId for a network where the protocol isn't deployed will result in a ChainNotConfigured error.


### PR DESCRIPTION
- updates the Quick Start guide in the documentation to clarify how the Boost SDK handles chain targeting and address resolution. 