### PR TITLE
[ADHOC]: Add claiming examples and API references

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -230,7 +230,8 @@
 			"version": "v2",
 			"pages": [
 				"v2/boost-sdk/boost-core/overview",
-				"v2/boost-sdk/boost-core/get-boosts"
+				"v2/boost-sdk/boost-core/get-boosts",
+				"v2/boost-sdk/boost-core/claim-incentive"
 			]
 		}
   ],

--- a/mint.json
+++ b/mint.json
@@ -213,7 +213,8 @@
 			"version": "v2",
 			"pages": [
 				"v2/boost-sdk/examples/zora-mint",
-				"v2/boost-sdk/examples/agora-vote"
+				"v2/boost-sdk/examples/agora-vote",
+				"v2/boost-sdk/examples/claim-example"
 			]
 		},
 		{

--- a/v2/boost-sdk/boost-core/claim-incentive.mdx
+++ b/v2/boost-sdk/boost-core/claim-incentive.mdx
@@ -6,3 +6,81 @@ import SDKDisclaimer from '/snippets/sdk-disclaimer.mdx';
 import ReadParams from '/snippets/read-params.mdx';
 
 <SDKDisclaimer />
+
+## API
+
+### `claimIncentive`
+
+Claims one incentive from a given `Boost` by `boostId` and `incentiveId`
+
+```ts
+// get the boost you want to claim from
+const boost = await core.getBoost(1n)
+
+// get the incentive you want to claim off the boost object
+const incentive = boost.incentives[0]
+
+// prepare the incentive payload
+let incentivePayload
+
+if (incentive instanceof ERC20Incentive) {
+  const reward = await incentive.reward()
+  const asset = await incentive.asset()
+  const limit = await incentive.limit()
+  const strategy = await incentive.strategy()
+
+  incentivePayload = prepareERC20IncentivePayload({
+    asset,
+    reward,
+    limit,
+    strategy,
+  })
+}
+
+// encode claimData payload
+const claimDataPayload = await boost.validator.encodeClaimData({
+  signer: accounts[0],
+  incentiveData: incentivePayload,
+  chainId: sepolia.id,
+  incentiveQuantity: 1,
+  claimant: account.address,
+  boostId: boost.id,
+});
+
+// claim the incentive from the boost
+await core.claimIncentive(
+  boost.id,
+  0n,
+  account.address, // the claimant
+  claimDataPayload,
+  { value: parseEther('0.000075') }, // claim fee
+);
+```
+
+#### Parameters
+
+<ParamField path="boostId" type="string | bigint" required>
+A `bigint`, or numerical string, or hexadecimal string.
+</ParamField>
+
+<ParamField path="incentiveId" type="string | bigint" required>
+A `bigint`, or numerical string, or hexadecimal string.
+</ParamField>
+
+<ParamField path="address" type="string" required>
+An address representing the claimant of the incentive.
+</ParamField>
+
+<ParamField path="claimDataPayload" type="string" required>
+A hexadecimal string containing the encoded claim data payload.
+</ParamField>
+
+<ParamField path="claimFee" type="string" required>
+A `string`, or hexadecimal string.
+</ParamField>
+
+<WriteParams />
+
+#### Returns
+
+<ResponseField name="void" type="Promise<void>" />

--- a/v2/boost-sdk/boost-core/claim-incentive.mdx
+++ b/v2/boost-sdk/boost-core/claim-incentive.mdx
@@ -39,11 +39,11 @@ if (incentive instanceof ERC20Incentive) {
 
 // encode claimData payload
 const claimDataPayload = await boost.validator.encodeClaimData({
-  signer: accounts[0],
+  signer: signer.account,
   incentiveData: incentivePayload,
-  chainId: sepolia.id,
+  chainId: 8453,
   incentiveQuantity: 1,
-  claimant: account.address,
+  claimant: "0xADDRESS", // the address of the account claiming the incentive
   boostId: boost.id,
 });
 

--- a/v2/boost-sdk/boost-core/claim-incentive.mdx
+++ b/v2/boost-sdk/boost-core/claim-incentive.mdx
@@ -71,12 +71,12 @@ await core.claimIncentiveFor(
 
 #### Parameters
 
-<ParamField path="boostId" type="string | bigint" required>
-A `bigint`, or numerical string representing the boost ID.
+<ParamField path="boostId" type="bigint" required>
+A `bigint` representing the boost ID.
 </ParamField>
 
-<ParamField path="incentiveId" type="string | bigint" required>
-A `bigint`, or numerical string representing the incentive ID.
+<ParamField path="incentiveId" type="bigint" required>
+A `bigint` representing the incentive ID. The incentive ID is the index of the incentive in the `incentives` array.
 </ParamField>
 
 <ParamField path="referrer" type="string" required>

--- a/v2/boost-sdk/boost-core/claim-incentive.mdx
+++ b/v2/boost-sdk/boost-core/claim-incentive.mdx
@@ -11,47 +11,17 @@ import ReadParams from '/snippets/read-params.mdx';
 
 ### `claimIncentive`
 
-Claims one incentive from a given `Boost` by `boostId` and `incentiveId`
+Claims one incentive from a boost. Must be called by claimant.
+
+<Info>
+  To learn how to encode the `claimDataPayload`, see the full [Claim Example](/v2/boost-sdk/examples/claim-example).
+</Info>
 
 ```ts
-// get the boost you want to claim from
-const boost = await core.getBoost(1n)
-
-// get the incentive you want to claim off the boost object
-const incentive = boost.incentives[0]
-
-// prepare the incentive payload
-let incentivePayload
-
-if (incentive instanceof ERC20Incentive) {
-  const reward = await incentive.reward()
-  const asset = await incentive.asset()
-  const limit = await incentive.limit()
-  const strategy = await incentive.strategy()
-
-  incentivePayload = prepareERC20IncentivePayload({
-    asset,
-    reward,
-    limit,
-    strategy,
-  })
-}
-
-// encode claimData payload
-const claimDataPayload = await boost.validator.encodeClaimData({
-  signer: signer.account,
-  incentiveData: incentivePayload,
-  chainId: 8453,
-  incentiveQuantity: 1,
-  claimant: "0xADDRESS", // the address of the account claiming the incentive
-  boostId: boost.id,
-});
-
-// claim the incentive from the boost
 await core.claimIncentive(
   boost.id,
   0n,
-  account.address, // the claimant
+  '0xCLAIMANT', // the claimant
   claimDataPayload,
   { value: parseEther('0.000075') }, // claim fee
 );
@@ -71,12 +41,59 @@ A `bigint`, or numerical string, or hexadecimal string.
 An address representing the claimant of the incentive.
 </ParamField>
 
-<ParamField path="claimDataPayload" type="string" required>
+<ParamField path="data" type="string" required>
 A hexadecimal string containing the encoded claim data payload.
 </ParamField>
 
 <ParamField path="claimFee" type="string" required>
 A `string`, or hexadecimal string.
+</ParamField>
+
+<WriteParams />
+
+#### Returns
+
+<ResponseField name="void" type="Promise<void>" />
+
+### `claimIncentiveFor`
+
+ Claim an incentive for a Boost on behalf of another user. 
+
+<Info>
+  To learn how to encode the `claimDataPayload`, see the full [Claim Example](/v2/boost-sdk/examples/claim-example).
+</Info>
+
+ ```ts
+await core.claimIncentiveFor(
+  boost.id,
+  0n, // the position of the incentive in the incentive array
+  "0xREFERER", // referrer (if any) use zero address if no referrer
+  claimDataPayload,
+  "0xCLAIMANT", // the address of the account the claim is being made for
+  { value: parseEther('0.000075') }, // claim fee
+);
+```
+
+#### Parameters
+
+<ParamField path="boostId" type="string | bigint" required>
+A `bigint`, or numerical string representing the boost ID.
+</ParamField>
+
+<ParamField path="incentiveId" type="string | bigint" required>
+A `bigint`, or numerical string representing the incentive ID.
+</ParamField>
+
+<ParamField path="referrer" type="string" required>
+The address of the referrer (if any). Use zero address if no referrer.
+</ParamField>
+
+<ParamField path="data" type="string" required>
+A hexadecimal string containing the encoded claim data payload.
+</ParamField>
+
+<ParamField path="claimant" type="string" required>
+The address of the user eligible for the incentive payout
 </ParamField>
 
 <WriteParams />

--- a/v2/boost-sdk/boost-core/claim-incentive.mdx
+++ b/v2/boost-sdk/boost-core/claim-incentive.mdx
@@ -4,6 +4,7 @@ title: "Claiming Incentives"
 
 import SDKDisclaimer from '/snippets/sdk-disclaimer.mdx';
 import ReadParams from '/snippets/read-params.mdx';
+import WriteParams from '/snippets/write-params.mdx';
 
 <SDKDisclaimer />
 
@@ -20,21 +21,20 @@ Claims one incentive from a boost. Must be called by claimant.
 ```ts
 await core.claimIncentive(
   boost.id,
-  0n,
+  0n, // the position of the incentive in the incentive array
   '0xCLAIMANT', // the claimant
   claimDataPayload,
-  { value: parseEther('0.000075') }, // claim fee
 );
 ```
 
 #### Parameters
 
-<ParamField path="boostId" type="string | bigint" required>
-A `bigint`, or numerical string, or hexadecimal string.
+<ParamField path="boostId" type="bigint" required>
+A `bigint` representing the boost ID.
 </ParamField>
 
-<ParamField path="incentiveId" type="string | bigint" required>
-A `bigint`, or numerical string, or hexadecimal string.
+<ParamField path="incentiveId" type="bigint" required>
+A `bigint` representing the incentive ID. The incentive ID is the index of the incentive in the `incentives` array.
 </ParamField>
 
 <ParamField path="address" type="string" required>
@@ -43,10 +43,6 @@ An address representing the claimant of the incentive.
 
 <ParamField path="data" type="string" required>
 A hexadecimal string containing the encoded claim data payload.
-</ParamField>
-
-<ParamField path="claimFee" type="string" required>
-A `string`, or hexadecimal string.
 </ParamField>
 
 <WriteParams />
@@ -67,10 +63,9 @@ A `string`, or hexadecimal string.
 await core.claimIncentiveFor(
   boost.id,
   0n, // the position of the incentive in the incentive array
-  "0xREFERER", // referrer (if any) use zero address if no referrer
+  "0xREFERER", // referrer (if any). use zero address if no referrer
   claimDataPayload,
   "0xCLAIMANT", // the address of the account the claim is being made for
-  { value: parseEther('0.000075') }, // claim fee
 );
 ```
 

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Claiming Incentives"
+title: "Claim Rewards from a Boost"
 description: Learn how to claim rewards from a Boost
 ---
 In this example, you'll learn how to claim a reward from a Boost.

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -26,8 +26,8 @@ let incentivePayload: Hex;
 // variable reward incentives require the reward amount to be provided in buildClaimData
 if (incentive instanceof ERC20VariableIncentive || 
     incentive instanceof ERC20VariableCriteriaIncentive) {
-  const variableRewardAmount = parseUnits("10", 18);
-  incentivePayload = incentive.buildClaimData(variableRewardAmount);
+  const rewardAmount = parseUnits("10", 18);
+  incentivePayload = incentive.buildClaimData(rewardAmount);
 } else {
   incentivePayload = incentive.buildClaimData();
 }

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -1,0 +1,65 @@
+---
+title: "Claiming ERC20 Incentives"
+description: Learn how to claim ERC20 rewards from a Boost
+---
+
+Boost Protocol allows users to claim ERC20 rewards from Boosts. This process involves interacting with the Boost contract to verify eligibility and receive the allocated incentives. 
+
+To claim an ERC20 reward from a Boost, you'll need to follow these general steps:
+
+1. Retrieve the Boost you want to claim from
+2. Get the specific incentive from the Boost
+3. Prepare the incentive payload
+4. Encode the claim data
+5. Execute the claim transaction
+
+```ts
+// get the boost you want to claim from
+const boost = await core.getBoost(1n)
+
+// get the incentive you want to claim off the boost object
+const incentive = boost.incentives[0]
+
+// prepare the incentive payload
+let incentivePayload
+
+if (incentive instanceof ERC20VariableIncentive) {
+  const incentivePayload = await incentive.buildClaimData(1n)
+}
+
+// encode claimData payload
+const claimDataPayload = await boost.validator.encodeClaimData({
+  signer: signer.account,
+  incentiveData: incentivePayload,
+  chainId: 8453,
+  incentiveQuantity: 1,
+  claimant: "0xCLAIMANT", // the address of the account claiming the incentive
+  boostId: boost.id,
+});
+
+// claim the incentive from the boost
+await core.claimIncentive(
+  boost.id,
+  0n, // position in the array of incentives
+  account.address, // the claimant
+  claimDataPayload,
+  { value: parseEther('0.000075') }, // claim fee
+);
+```
+
+<Warning>
+  The claimant must be authorized to claim the incentive. (*ie: on allowlist and passes validation*)
+</Warning>
+
+You can also claim on behalf of another user by using the `claimIncentiveFor` method.
+
+```ts
+await core.claimIncentiveFor(
+  boost.id,
+  0n, // the incentiveId (0n is for the ERC20Incentive strategy)
+  "0xREFERER", // referrer (if any) use zero address if no referrer
+  claimDataPayload,
+  "0xCLAIMANT", // the address of the account the claim is being made for
+  { value: parseEther('0.000075') }, // claim fee
+);
+```

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -16,38 +16,38 @@ To claim a reward from a Boost, you'll need to follow these general steps:
 // get the boost you want to claim from
 const boost = await core.getBoost(1n)
 
-// get the incentive you want to claim off the boost object
-const incentive = boost.incentives[0]
+// loop through the incentives available on the boost
+boost.incentives.forEach(async (incentive, incentiveId) => {
+  // prepare the incentive payload
+  let incentivePayload: Hex;
 
-// prepare the incentive payload
-let incentivePayload: Hex;
+  // variable reward incentives require the reward amount to be provided in buildClaimData
+  if (incentive instanceof ERC20VariableIncentive || 
+      incentive instanceof ERC20VariableCriteriaIncentive) {
+    const variableRewardAmount = 1n;
+    incentivePayload = incentive.buildClaimData(variableRewardAmount);
+  } else {
+    incentivePayload = incentive.buildClaimData();
+  }
 
-// variable reward incentives require the reward amount to be provided in buildClaimData
-if (incentive instanceof ERC20VariableIncentive || 
-    incentive instanceof ERC20VariableCriteriaIncentive) {
-  const variableRewardAmount = 1n;
-  incentivePayload = await incentive.buildClaimData(variableRewardAmount);
-} else {
-  incentivePayload = incentive.buildClaimData();
-}
+  // encode claimData payload
+  const claimDataPayload = await boost.validator.encodeClaimData({
+    signer: signer.account,
+    incentiveData: incentivePayload,
+    chainId: 8453,
+    incentiveQuantity: 1,
+    claimant: "0xCLAIMANT", // the address of the account claiming the incentive
+    boostId: boost.id,
+  });
 
-// encode claimData payload
-const claimDataPayload = await boost.validator.encodeClaimData({
-  signer: signer.account,
-  incentiveData: incentivePayload,
-  chainId: 8453,
-  incentiveQuantity: 1,
-  claimant: "0xCLAIMANT", // the address of the account claiming the incentive
-  boostId: boost.id,
-});
-
-// claim the incentive from the boost
-await core.claimIncentive(
-  boost.id,
-  0n, // the incentiveId (position in the array of incentives)
-  "0xCLAIMANT", // the claimant
-  claimDataPayload,
-);
+  // claim the incentive from the boost
+  await core.claimIncentive(
+    boost.id,
+    incentiveId, // the incentiveId (position in the array of incentives)
+    "0xCLAIMANT", // the claimant
+    claimDataPayload,
+  );
+})
 ```
 
 <Warning>

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -17,7 +17,7 @@ To claim a reward from a Boost, you'll need to follow these general steps:
 const boost = await core.getBoost(1n)
 
 // get an incentive from the boost
-const incentiveId = 0n;
+const incentiveId = 0n; // the position in the incentives array
 const incentive = boost.incentives[incentiveId]
 
 // prepare the incentive payload
@@ -26,7 +26,7 @@ let incentivePayload: Hex;
 // variable reward incentives require the reward amount to be provided in buildClaimData
 if (incentive instanceof ERC20VariableIncentive || 
     incentive instanceof ERC20VariableCriteriaIncentive) {
-  const variableRewardAmount = 1n;
+  const variableRewardAmount = parseUnits("10", 18);
   incentivePayload = incentive.buildClaimData(variableRewardAmount);
 } else {
   incentivePayload = incentive.buildClaimData();
@@ -61,7 +61,7 @@ You can also claim on behalf of another user by using the `claimIncentiveFor` me
 await core.claimIncentiveFor(
   boost.id,
   0n, // the incentiveId (position in the array of incentives)
-  "0xREFERER", // referrer (if any). use zero address if no referrer
+  "0xREFERRER", // referrer (if any). use zero address if no referrer
   claimDataPayload,
   "0xCLAIMANT", // the address of the account the claim is being made for
 );

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -1,11 +1,10 @@
 ---
-title: "Claiming ERC20 Incentives"
-description: Learn how to claim ERC20 rewards from a Boost
+title: "Claiming Incentives"
+description: Learn how to claim rewards from a Boost
 ---
+In this example, you'll learn how to claim a reward from a Boost.
 
-Boost Protocol allows users to claim ERC20 rewards from Boosts. This process involves interacting with the Boost contract to verify eligibility and receive the allocated incentives. 
-
-To claim an ERC20 reward from a Boost, you'll need to follow these general steps:
+To claim a reward from a Boost, you'll need to follow these general steps:
 
 1. Retrieve the Boost you want to claim from
 2. Get the specific incentive from the Boost
@@ -21,10 +20,15 @@ const boost = await core.getBoost(1n)
 const incentive = boost.incentives[0]
 
 // prepare the incentive payload
-let incentivePayload
+let incentivePayload: Hex;
 
-if (incentive instanceof ERC20VariableIncentive) {
-  const incentivePayload = await incentive.buildClaimData(1n)
+// variable reward incentives require the reward amount to be provided in buildClaimData
+if (incentive instanceof ERC20VariableIncentive || 
+    incentive instanceof ERC20VariableCriteriaIncentive) {
+  const variableRewardAmount = 1n;
+  incentivePayload = await incentive.buildClaimData(variableRewardAmount);
+} else {
+  incentivePayload = incentive.buildClaimData();
 }
 
 // encode claimData payload
@@ -40,10 +44,9 @@ const claimDataPayload = await boost.validator.encodeClaimData({
 // claim the incentive from the boost
 await core.claimIncentive(
   boost.id,
-  0n, // position in the array of incentives
-  account.address, // the claimant
+  0n, // the incentiveId (position in the array of incentives)
+  "0xCLAIMANT", // the claimant
   claimDataPayload,
-  { value: parseEther('0.000075') }, // claim fee
 );
 ```
 
@@ -56,10 +59,9 @@ You can also claim on behalf of another user by using the `claimIncentiveFor` me
 ```ts
 await core.claimIncentiveFor(
   boost.id,
-  0n, // the incentiveId (0n is for the ERC20Incentive strategy)
-  "0xREFERER", // referrer (if any) use zero address if no referrer
+  0n, // the incentiveId (position in the array of incentives)
+  "0xREFERER", // referrer (if any). use zero address if no referrer
   claimDataPayload,
   "0xCLAIMANT", // the address of the account the claim is being made for
-  { value: parseEther('0.000075') }, // claim fee
 );
 ```

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -16,38 +16,39 @@ To claim a reward from a Boost, you'll need to follow these general steps:
 // get the boost you want to claim from
 const boost = await core.getBoost(1n)
 
-// loop through the incentives available on the boost
-boost.incentives.forEach(async (incentive, incentiveId) => {
-  // prepare the incentive payload
-  let incentivePayload: Hex;
+// get an incentive from the boost
+const incentiveId = 0n;
+const incentive = boost.incentives[incentiveId]
 
-  // variable reward incentives require the reward amount to be provided in buildClaimData
-  if (incentive instanceof ERC20VariableIncentive || 
-      incentive instanceof ERC20VariableCriteriaIncentive) {
-    const variableRewardAmount = 1n;
-    incentivePayload = incentive.buildClaimData(variableRewardAmount);
-  } else {
-    incentivePayload = incentive.buildClaimData();
-  }
+// prepare the incentive payload
+let incentivePayload: Hex;
 
-  // encode claimData payload
-  const claimDataPayload = await boost.validator.encodeClaimData({
-    signer: signer.account,
-    incentiveData: incentivePayload,
-    chainId: 8453,
-    incentiveQuantity: 1,
-    claimant: "0xCLAIMANT", // the address of the account claiming the incentive
-    boostId: boost.id,
-  });
+// variable reward incentives require the reward amount to be provided in buildClaimData
+if (incentive instanceof ERC20VariableIncentive || 
+    incentive instanceof ERC20VariableCriteriaIncentive) {
+  const variableRewardAmount = 1n;
+  incentivePayload = incentive.buildClaimData(variableRewardAmount);
+} else {
+  incentivePayload = incentive.buildClaimData();
+}
 
-  // claim the incentive from the boost
-  await core.claimIncentive(
-    boost.id,
-    incentiveId, // the incentiveId (position in the array of incentives)
-    "0xCLAIMANT", // the claimant
-    claimDataPayload,
-  );
-})
+// encode claimData payload
+const claimDataPayload = await boost.validator.encodeClaimData({
+  signer: signer.account,
+  incentiveData: incentivePayload,
+  chainId: 8453,
+  incentiveQuantity: 1,
+  claimant: "0xCLAIMANT", // the address of the account claiming the incentive
+  boostId: boost.id,
+});
+
+// claim the incentive from the boost
+await core.claimIncentive(
+  boost.id,
+  incentiveId, // the incentiveId (position in the array of incentives)
+  "0xCLAIMANT", // the claimant
+  claimDataPayload,
+);
 ```
 
 <Warning>


### PR DESCRIPTION
- Adds an end-to-end example of claiming in the Examples section.
- Adds API references for `claimIncentive` and `claimIncentiveFor`