### PR TITLE
[ADHOC] update V1 links to use correct versioning prefix

### DIFF
--- a/v1/boost-api/create-a-boost.mdx
+++ b/v1/boost-api/create-a-boost.mdx
@@ -7,15 +7,15 @@ description: How to create a boost using the Boost API
 
 Creating a boost via the Boost API requires the following:
 
-* An [access token](/boost-api/sign-in-to-boost) from the Boost API for the end user deploying the boost
+* An [access token](/v1/boost-api/sign-in-to-boost) from the Boost API for the end user deploying the boost
 * ActionParam type definitions from the BoostDK, which can be referenced [here](https://github.com/rabbitholegg/questdk/blob/main/src/actions/types.ts) or installed with:
 `npm install @rabbitholegg/questdk`
 * The ABI file for the boost factory contract, which can be found [here](https://github.com/rabbitholegg/questdk/blob/main/src/abi/quest-factory.ts)
-* Project ID and task ID values for the chosen action to boost, [queried from the Boost API](/boost-api/create-a-boost#querying-approved-projects-and-tasks)
-* An [individual reward amount and boost participant limit](/boost-api/create-a-boost#selecting-a-reward-amount-and-participant-limit)
+* Project ID and task ID values for the chosen action to boost, [queried from the Boost API](/v1/boost-api/create-a-boost#querying-approved-projects-and-tasks)
+* An [individual reward amount and boost participant limit](/v1/boost-api/create-a-boost#selecting-a-reward-amount-and-participant-limit)
 * An end time and optional start time
 
-All of the above data is [submitted to the POST /boosts endpoint](/boost-api/create-a-boost#submitting-the-create-boost-request), after which a [transaction must be submitted](/boost-api/create-a-boost#deploying-the-boost-contract) to the blockchain on the reward token blockchain to deploy a new contract specific to the newly created boost.
+All of the above data is [submitted to the POST /boosts endpoint](/v1/boost-api/create-a-boost#submitting-the-create-boost-request), after which a [transaction must be submitted](/v1/boost-api/create-a-boost#deploying-the-boost-contract) to the blockchain on the reward token blockchain to deploy a new contract specific to the newly created boost.
 
 ## Querying approved projects and tasks
 

--- a/v1/boost-api/fetch-boosts.mdx
+++ b/v1/boost-api/fetch-boosts.mdx
@@ -17,7 +17,7 @@ const { boosts } = await creatorFilteredBoostsResponse.json();
 
 ## Querying boosts by project
 
-To query all boosts for a specific project, use the [GET /boosts endpoint](/v1/api-reference/boosts/boosts) with the `projectIds` query parameter. Project ID values can be queried from the [GET /manager/projects](/v1/api-reference/manager/projects) endpoint, detailed on the [Create a Boost page](/boost-api/create-a-boost#querying-approved-projects-and-tasks).
+To query all boosts for a specific project, use the [GET /boosts endpoint](/v1/api-reference/boosts/boosts) with the `projectIds` query parameter. Project ID values can be queried from the [GET /manager/projects](/v1/api-reference/manager/projects) endpoint, detailed on the [Create a Boost page](/v1/boost-api/create-a-boost#querying-approved-projects-and-tasks).
 
 The following example queries all Aerodrome and Velodrome boosts created by a set of addresses:
 

--- a/v1/overview/how-it-works.mdx
+++ b/v1/overview/how-it-works.mdx
@@ -4,7 +4,7 @@ title: 'How It Works'
 
 Boost is a permissionless protocol that anyone can access and build on to deploy incentive offers.
 
-There are several different ways to interact with the protocol depending on [your role](boost-protocol#key-contributors) in the ecosystem. To understand how it works, it’s important to get familiar with the core components that make up the Boost stack:
+There are several different ways to interact with the protocol depending on [your role](/v1/overview/boost-protocol#key-contributors) in the ecosystem. To understand how it works, it’s important to get familiar with the core components that make up the Boost stack:
 
 <Frame caption="Boost Ecosystem Overview">
     <img src="/assets/boost-ecosystem-overview.png" alt="boost ecosystem overview" />


### PR DESCRIPTION
Fixes a few broken links in V1. They needed the version prefix (ie: /v1/)