### PR TITLE
[BOOST-4900]: revisiting examples flesh out and update with signatures

### DIFF
--- a/v2/boost-sdk/budgets/managed/authorization.mdx
+++ b/v2/boost-sdk/budgets/managed/authorization.mdx
@@ -258,7 +258,7 @@ The address to check roles for.
 
 ### `owner`
 
-Returns the owner of the budgets address.
+Returns the budget owner's address.
 
 ```ts
 await budget.owner();

--- a/v2/boost-sdk/examples/agora-vote.mdx
+++ b/v2/boost-sdk/examples/agora-vote.mdx
@@ -3,6 +3,8 @@ title: "Boost a Vote on Agora"
 description: Learn how to reward users with ERC20 rewards when they vote for/against a specific proposal
 ---
 
+import Config from '/snippets/config.mdx'
+
 In this example, you want a certain proposal to pass/fail, and want to incentivize users to swing votes in your favor by offering additional rewards.
 
 <Card title="See the code" icon="file-lines" href="https://boost-protocol.vercel.app/classes/Contract.html#getLogs">See technical documentation for `Contract.getLogs`</Card>
@@ -11,13 +13,20 @@ In this example, you want a certain proposal to pass/fail, and want to incentivi
 Make sure you've completed the [quick start](/v2/boost-sdk/quick-start) guide before proceeding with this example.
 </Warning>
 
+## Set up a Managed Budget
+
 First you'll need to either initialize a new budget, or use an existing one, and allow the budget to spend a certain amount of your selected ERC20.
 
-```ts
-import { BoostCore } from '@boostxyz/sdk/BoostCore'
-import { BoostRegistry } from '@boostxyz/sdk/BoostRegistry'
-import { ManagedBudget, ManagedBudgetRoles } from '@boostxyz/sdk/Budgets/ManagedBudget'
+<CodeGroup>
+```ts index.ts
+import { 
+  BoostCore, 
+  BoostRegistry, 
+  ManagedBudget, 
+  Roles 
+} from '@boostxyz/sdk'
 import { parseUnits } from 'viem'
+import { config as wagmiConfig } from './config'
 
 // Initialize the BoostCore and BoostRegistry modules
 const registry = new BoostRegistry({ config: wagmiConfig }),
@@ -30,7 +39,7 @@ const coreAddress = core.assertValidAddress()
 const budget = await registry.initialize('MyNewBudget', core.ManagedBudget({
   owner: '0xME',
   authorized: ['0xME', coreAddress],
-  roles: [ManagedBudgetRoles.ADMIN, ManagedBudgetRoles.MANAGER]
+  roles: [Roles.ADMIN, Roles.MANAGER]
 }))
 
 // Allow the budget to spend your ERC20 token
@@ -51,6 +60,10 @@ await budget.allocate({
   target: '0xME',
 })
 ```
+<Config />
+</CodeGroup>
+
+## Define The Action
 
 Next you'll need to define the action that qualifies a user to claim the reward.
 
@@ -130,7 +143,6 @@ const filterSupportStep: ActionStep = {
 };
 ```
 
-
 Next, we need to define the action claimant and create the payload for the new event action.
 
 The `eventAction` payload consists of the `actionClaimant` and the `actionSteps` we defined previously.
@@ -144,7 +156,7 @@ The purpose of the `eventAction` is to track and reward users based on their int
 
 2. **actionSteps**: This array can contain up to four action steps that outline the specific actions or conditions that must be met for the event action to be valid. In this example, we include the previously defined `eventActionStepOne` and `eventActionStepTwo`.
 
-Next, we initialize the `EventAction` class from the `bases` module, passing in the default options and the constructed `eventActionPayload`. This creates a new event action.
+Next, we use `core.EventAction` to set up the event action with our constructed `eventActionPayload`.
 
 ```ts
 const eventActionPayload = {
@@ -162,10 +174,13 @@ const eventActionPayload = {
 const eventAction = core.EventAction(eventActionPayload);
 ```
 
+## Deploy the Boost
+
 Once the event action is created, we can set up the incentives and deploy our boost.
 
 ```ts
-// This allows for participants to be rewarded with up to 10 wei of the reward asset. The maximum amount of the rewards distributed by this incentive in this boost would be 100 wei
+// This allows for participants to be rewarded with up to 10 wei of the reward asset. 
+//The maximum amount of the rewards distributed by this incentive in this boost would be 100 wei
 const incentives = [
     core.ERC20VariableIncentive({
       asset: erc20.assertValidAddress(),
@@ -177,30 +192,36 @@ const incentives = [
 
 ```ts
 // Deploy the boost
-await core.createBoost({
+const boost = await core.createBoost({
   maxParticipants: 100n, // Set a max number of participants
   budget: budget, // Use the ManagedBudget we set up earlier
   action: eventAction, // Pass the manually created EventAction
   incentives: incentives,
-  validator: core.SignerValidator({
-    signers: [owner, trustedSigner.account],
-    validatorCaller: core.assertValidAddress(),
-  }),
-  // This allowlist makes this boost available to all addresses. If you want to limit it to a specific address, you can use a SimpleAllowList
   allowList: core.OpenAllowList(),
 });
 ```
 
-After the boost is created, we can then implement logic to determine dynamic rewards.
+<Tip>
+  `core.OpenAllowList()` makes this boost available to all addresses. If you want to limit it to a specific address, you can use a `SimpleAllowList`.
+</Tip>
+
+## Claiming Incentives
+
+Once a claimant has successfully voted, you can claim the incentive for that claimant. You will need the address of the user that cast the vote, the hash of the vote cast transaction, and the boost id. 
+But first, you'll need to implement some logic to determine the variable reward amount.
+
+<Tip>
+  `ERC20VariableIncentive` uses off-chain logic to determine the reward amount. If you would like to base your reward on on-chain logic, you can use the `ERC20VariableCriteriaIncentive` type.
+</Tip>
 
 ```ts
-// Check the amount of votes the boostImpostor has at the time they made the tx to vote
+// Check the amount of votes the claimant has at the time they made the tx to vote
 const getVotesAbi = functions.abi[functions.selectors['getVotes(address account, uint256 blockNumber) view returns (uint256)'] as '0x00000000000000000000000000000000000000000000000000000000eb9019d4']
 const amountOfVotes = (await walletClient.readContract({
   address: '0xcdf27f107725988f2261ce2256bdfcde8b382b10',
   abi: [getVotesAbi],
   functionName: 'getVotes',
-  args: ['0xME', 'blockNumber'],
+  args: [claimant, 127417170n], // claimant is the address of the user that cast the vote
 })) as bigint;
 
 // If the amountOfVotes is greater than 100, then the reward should be 0.1 ETH, otherwise it will be 0.01 ETH
@@ -210,29 +231,45 @@ const rewardAmount =
     : parseEther('0.01');
 ```
 
-Having the `rewardAmount` will allow us to use it as a param when generating the signature payload to allow the user to claim the reward.
+Once the reward amount is determined, we can generate the signature payload to allow us to claim the reward for the claimant. 
+To generate the signature payload you will need to call the Boost `/signatures` api endpoint with the following params:
+
+- `boostId`: The id of the boost where the action was completed. The format is `chainId:boostId` (e.g. `8453:69`)
+- `txHash`: The hash of the transaction that completed the action.
+- `claimData`: This is only nessecary for variableIncentives. For this parameter you would pass in the `rewardAmount` which is used to determine the amount of the incentive to claim.
+If you have more than one variable incentive you can pass in a comma-separated list of claimData values.
+
+The signatures api will return an array of signatures, one for each available incentive on the boost.
+
+[//]: # (TODO: link to api reference for /signatures)
+[//]: # (TODO: update link api link)
 
 ```ts
-// Generate the signature using the trusted signer
-const claimDataPayload = await boost.validator.encodeClaimData({
-  signer: trustedSigner,
-  incentiveData: encodeAbiParameters(
-    [{ name: '', type: 'uint256' }],
-    [rewardAmount],
-  ),
-  chainId: optimism.id,
-  incentiveQuantity: 1,
-  claimant: boostImpostor,
-  boostId: boost.id,
-});
+  import axios from 'axios';
 
-// Claim the incentive for the imposter
-await core.claimIncentiveFor(
-  boost.id,
-  0n,
-  referrer,
-  claimDataPayload,
-  boostImpostor,
-  { value: parseEther('0.000075') },
-);
+  const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+    params: { 
+      boostId: `${chainId}:${boost.id}`, 
+      txHash,
+      claimData: rewardAmount.toString(),
+    }
+  });
+
+  for (const item of data) {
+    const { signature, incentiveId, claimant } = item;
+
+    // Claim the incentive for the claimant
+    await core.claimIncentiveFor(
+      boost.id,
+      incentiveId,
+      referrer,
+      signature,
+      claimant,
+    );
+  }
 ```
+<Tip>
+  There can be multiple incentives to claim in a single boost. The example shown only has one incentive. 
+</Tip>
+
+The boost will stay active until the `maxParticipants` set for the boost is reached, or the incentive budget is fully spent.

--- a/v2/boost-sdk/examples/agora-vote.mdx
+++ b/v2/boost-sdk/examples/agora-vote.mdx
@@ -247,7 +247,7 @@ The signatures api will return an array of signatures, one for each available in
 ```ts
   import axios from 'axios';
 
-  const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+  const { data } = await axios.get('/signatures', {
     params: { 
       boostId: `${chainId}:${boost.id}`, 
       txHash,

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -33,7 +33,7 @@ otherwise you will need to build the payload yourself.
     const chainId = 8453; // base mainnet
     const boost = await core.getBoost(3n, { chainId })
 
-    const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+    const { data } = await axios.get('/signatures', {
       params: { 
         boostId: `${chainId}:${boost.id}`, 
         txHash,
@@ -62,7 +62,7 @@ otherwise you will need to build the payload yourself.
     const chainId = 8453; // base mainnet
     const boost = await core.getBoost(3n, { chainId })
 
-    const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+    const { data } = await axios.get('/signatures', {
       params: { 
         boostId: `${chainId}:${boost.id}`, 
         txHash,

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -7,62 +7,154 @@ In this example, you'll learn how to claim a reward from a Boost.
 To claim a reward from a Boost, you'll need to follow these general steps:
 
 1. Retrieve the Boost you want to claim from
-2. Get the specific incentive from the Boost
-3. Prepare the incentive payload
-4. Encode the claim data
-5. Execute the claim transaction
+2. Prepare the claim data payload
+3. Execute the claim transaction
 
-```ts
-// get the boost you want to claim from
-const boost = await core.getBoost(1n)
+This process will differ depending on if you have set up your own validator or are using the default validator.
+If using the default validator, you will need to call the boost's `/signatures` endpoint to generate the signature payload, 
+otherwise you will need to build the payload yourself.
 
-// get an incentive from the boost
-const incentiveId = 0n; // the position in the incentives array
-const incentive = boost.incentives[incentiveId]
+<Tip>
+  The default validator will be always be used by default unless you specify your own validator on boost creation.
+</Tip>
 
-// prepare the incentive payload
-let incentivePayload: Hex;
+<Tabs>
+  <Tab title="Using the Default Validator">
 
-// variable reward incentives require the reward amount to be provided in buildClaimData
-if (incentive instanceof ERC20VariableIncentive || 
-    incentive instanceof ERC20VariableCriteriaIncentive) {
-  const rewardAmount = parseUnits("10", 18);
-  incentivePayload = incentive.buildClaimData(rewardAmount);
-} else {
-  incentivePayload = incentive.buildClaimData();
-}
+    In order to claim an incentive from a boost using the default validator, you will need to generate a valid signature payload.
+    You can do this by calling the boost api `/signatures` endpoint and passing in the boostID and txHash.
 
-// encode claimData payload
-const claimDataPayload = await boost.validator.encodeClaimData({
-  signer: signer.account,
-  incentiveData: incentivePayload,
-  chainId: 8453,
-  incentiveQuantity: 1,
-  claimant: "0xCLAIMANT", // the address of the account claiming the incentive
-  boostId: boost.id,
-});
+    This example assumes you have already instantiated a `BoostCore` client and have a valid transaction hash for the action that the claimant completed.
 
-// claim the incentive from the boost
-await core.claimIncentive(
-  boost.id,
-  incentiveId, // the incentiveId (position in the array of incentives)
-  "0xCLAIMANT", // the claimant
-  claimDataPayload,
-);
-```
+    ### Generate the Signature Payload
+    ```ts
+    import axios from 'axios';
 
-<Warning>
-  The claimant must be authorized to claim the incentive. (*ie: on allowlist and passes validation*)
-</Warning>
+    const chainId = 8453; // base mainnet
+    const boost = await core.getBoost(3n, { chainId })
 
-You can also claim on behalf of another user by using the `claimIncentiveFor` method.
+    const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+      params: { 
+        boostId: `${chainId}:${boost.id}`, 
+        txHash,
+      }
+    });
+    ```
+    [//]: # (TODO: add link to api reference)
 
-```ts
-await core.claimIncentiveFor(
-  boost.id,
-  0n, // the incentiveId (position in the array of incentives)
-  "0xREFERRER", // referrer (if any). use zero address if no referrer
-  claimDataPayload,
-  "0xCLAIMANT", // the address of the account the claim is being made for
-);
-```
+    <Tip>
+      If using `ERC20VariableIncentive` or `ERC20VariableCriteriaIncentive`, you will need to pass in the `rewardAmount` as `claimData` to the `/signatures` endpoint.
+    </Tip>
+
+    The `/signatures` endpoint will return an array of signatures, one for each available incentive on the boost.
+    Each item in the array will contain the following fields:
+    - `signature`: The signature to be used in the claim transaction
+    - `incentiveId`: The id of the incentive being claimed
+    - `claimant`: The address of the claimant
+
+    ### Claiming the incentives
+
+    Once you have a valid response from the `/signatures` endpoint, you can loop through the response and claim the incentives.
+
+    ```ts index.ts {13-22}
+    import axios from 'axios';
+
+    const chainId = 8453; // base mainnet
+    const boost = await core.getBoost(3n, { chainId })
+
+    const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+      params: { 
+        boostId: `${chainId}:${boost.id}`, 
+        txHash,
+      }
+    });
+
+    for (const item of data) {
+      const { signature, incentiveId, claimant } = item;
+
+      // Allow the claimant to claim the incentive
+      await core.claimIncentive(
+        boost.id,
+        incentiveId,
+        claimant,
+        signature,
+      );
+    } 
+    ```
+    <Warning>
+      `claimIncentive` must be called by the claimant. This is useful if you have access to the claimants wallet, like in the case of a dapp.
+      If you are claiming on behalf of another user, you must use `claimIncentiveFor`.
+    </Warning>
+
+    You can also claim on behalf of another user by using the `claimIncentiveFor` method.
+
+    ```ts
+    // Claim on behalf of another user
+    await core.claimIncentiveFor(
+      boost.id,
+      incentiveId, // the incentiveId (position in the array of incentives)
+      "0xREFERRER", // referrer (if any). use zero address if no referrer
+      signature,
+      claimant, // the address of the account the claim is being made for
+    );
+    ```
+  </Tab>
+  <Tab title="Using Your Own Validator" >
+    [//]: # (TODO: link to validator page when it's published to provde more context)
+    [//]: # (TODO: show how to validate actions without using the api)
+    ```ts
+    // get the boost you want to claim from
+    const boost = await core.getBoost(1n)
+
+    // get an incentive from the boost
+    const incentiveId = 0n; // the position in the incentives array
+    const incentive = boost.incentives[incentiveId]
+
+    // prepare the incentive payload
+    let incentivePayload: Hex;
+
+    // variable reward incentives require the reward amount to be provided in buildClaimData
+    if (incentive instanceof ERC20VariableIncentive || 
+        incentive instanceof ERC20VariableCriteriaIncentive) {
+      const rewardAmount = parseUnits("10", 18);
+      incentivePayload = incentive.buildClaimData(rewardAmount);
+    } else {
+      incentivePayload = incentive.buildClaimData();
+    }
+
+    // encode claimData payload
+    const claimDataPayload = await boost.validator.encodeClaimData({
+      signer: signer.account,
+      incentiveData: incentivePayload,
+      chainId: 8453,
+      incentiveQuantity: 1,
+      claimant: "0xCLAIMANT", // the address of the account claiming the incentive
+      boostId: boost.id,
+    });
+
+    // claim the incentive from the boost
+    await core.claimIncentive(
+      boost.id,
+      incentiveId, // the incentiveId (position in the array of incentives)
+      "0xCLAIMANT", // the claimant
+      claimDataPayload,
+    );
+    ```
+
+    <Warning>
+      The claimant must be authorized to claim the incentive (e.g., on allowlist)
+    </Warning>
+
+    You can also claim on behalf of another user by using the `claimIncentiveFor` method.
+
+    ```ts
+    await core.claimIncentiveFor(
+      boost.id,
+      0n, // the incentiveId (position in the array of incentives)
+      "0xREFERRER", // referrer (if any). use zero address if no referrer
+      claimDataPayload,
+      "0xCLAIMANT", // the address of the account the claim is being made for
+    );
+    ```
+  </Tab>
+</Tabs>

--- a/v2/boost-sdk/examples/zora-mint.mdx
+++ b/v2/boost-sdk/examples/zora-mint.mdx
@@ -3,11 +3,15 @@ title: "Boost an NFT Mint on Zora"
 description: Learn how to reward users with ERC20 rewards when they mint an NFT on Zora.
 ---
 
+import { Config } from '../config'
+
 In this example, you've created an NFT on Zora, and want to incentivize users to mint it by offering additional rewards.
 
 <Warning>
 Make sure you've completed the [quick start](/v2/boost-sdk/quick-start) guide before proceeding with this example.
 </Warning>
+
+## Set up a Managed Budget
 
 First you'll need to either initialize a new budget, or use an existing one, and allow the budget to spend a certain amount of your selected ERC20.
 
@@ -15,7 +19,7 @@ First you'll need to either initialize a new budget, or use an existing one, and
 ```ts index.ts
 import { BoostCore } from '@boostxyz/sdk/BoostCore'
 import { BoostRegistry } from '@boostxyz/sdk/BoostRegistry'
-import { ManagedBudget, ManagedBudgetRoles } from '@boostxyz/sdk/Budgets/ManagedBudget'
+import { ManagedBudget, Roles } from '@boostxyz/sdk'
 import { parseUnits, erc20Abi } from 'viem'
 import { wagmiConfig } from '../config'
 
@@ -27,10 +31,10 @@ const core = new BoostCore({ config: wagmiConfig })
 const coreAddress = core.assertValidAddress()
 
 // Create a new budget and grant the correct permissions to the protocol
-const budget = await registry.initialize('MyNewBudget', core.ManagedBudget({
+const budget = await registry.initialize('MyBudget', core.ManagedBudget({
   owner: "0xME",
   authorized: ["0xME", coreAddress], // authorized addresses
-  roles: [ManagedBudgetRoles.ADMIN, ManagedBudgetRoles.MANAGER] // roles that the budget can assign to the protocol
+  roles: [Roles.ADMIN, Roles.MANAGER] // roles that the budget can assign to the protocol
 }))
 
 // Allow the budget to spend your ERC20 token.
@@ -51,20 +55,10 @@ await budget.allocate({
   target: "0xME",
 })
 ```
-
-```ts config.ts
-import { http, createConfig } from '@wagmi/core'
-import { mainnet, sepolia } from '@wagmi/core/chains'
-
-export const wagmiConfig = createConfig({
-  chains: [mainnet, sepolia],
-  transports: {
-    [mainnet.id]: http(),
-    [sepolia.id]: http(),
-  },
-})
-```
+<Config />
 </CodeGroup>
+
+## Define The Action
 
 Next you'll need to define the action that qualifies a user to claim the reward.
 
@@ -101,7 +95,7 @@ import {
 } from '@boostxyz/sdk/Actions/EventAction'
 import { selectors } from '@boostxyz/signatures/events'
 
-// If one exists, use the signature from the selectors package
+// Use the Purchased signature from the selectors package
 const selectedSignature = selectors[
   'Purchased(address indexed,address indexed,uint256 indexed,uint256,uint256)'
 ] as Hex;
@@ -121,7 +115,6 @@ const eventActionStep: ActionStep = {
 };
 
 ```
-
 
 Next, we need to define the action claimant and create the payload for the new event action.
 
@@ -153,12 +146,14 @@ const eventActionPayload = {
 const eventAction = core.EventAction(eventActionPayload);
 ```
 
-Once the event action is created, we can set up the incentives.
+## Deploy the Boost
+
+Once the event action is created, we can set up the incentives and deploy our boost.
 
 ```ts
-import { StrategyType } from '@boostxyz/sdk/Incentives'
+import { StrategyType } from '@boostxyz/sdk/Incentive'
 
-// This allows for 10 participants to be rewarded with 1 WETH each
+// This allows for 10 participants to be rewarded with 1 token each
 const incentives = [
     core.ERC20Incentive({
       asset: '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2',
@@ -169,8 +164,6 @@ const incentives = [
   ],
 ```
 
-Last step is to create the boost.
-
 ```ts
 // Deploy the boost
 const boost = await core.createBoost({
@@ -178,11 +171,54 @@ const boost = await core.createBoost({
   budget: budget, // Use the ManagedBudget we set up earlier
   action: eventAction, // Pass the manually created EventAction
   incentives: incentives,
-  validator: core.SignerValidator(defaultOptions, {
-    signers: [owner, trustedSigner.account],
-    validatorCaller: core.assertValidAddress(), 
-  }),
-  // The boost is available to all addresses. If you want to limit it to specific addresses, you can use a SimpleAllowList
   allowList: core.OpenAllowList(),
 });
 ```
+
+## Claiming Incentives
+
+Once a claimant has successfully completed the action, you can claim the incentive for that claimant. 
+
+<Tip>
+  `ERC20Incentive` is a fixed reward incentive. If you would like to have a variable reward based on on-chain logic, you can use the `ERC20VariableCriteriaIncentive` type.
+</Tip>
+
+In order to successfully claim the reward for a claimant, you will need to generate the signature payload. 
+To generate the signature payload you will need to call the Boost `/signatures` api endpoint with the following params:
+
+- `boostId`: The id of the boost where the action was completed. The format is `chainId:boostId` (e.g. `8453:69`)
+- `txHash`: The hash of the transaction that completed the action.
+
+The signatures api will return an array of signatures, one for each available incentive on the boost.
+
+[//]: # (TODO: link to api reference for /signatures)
+[//]: # (TODO: update link api link)
+
+```ts
+  import axios from 'axios';
+
+  const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+    params: { 
+      boostId: `${chainId}:${boost.id}`, 
+      txHash,
+    }
+  });
+
+  for (const item of data) {
+    const { signature, incentiveId, claimant } = item;
+
+    // Claim the incentive for the claimant
+    await core.claimIncentiveFor(
+      boost.id,
+      incentiveId,
+      referrer,
+      signature,
+      claimant,
+    );
+  }
+```
+<Tip>
+  There can be multiple incentives to claim in a single boost. The example shown only has one incentive. 
+</Tip>
+
+The boost will stay active until the `maxParticipants` set for the boost is reached.

--- a/v2/boost-sdk/examples/zora-mint.mdx
+++ b/v2/boost-sdk/examples/zora-mint.mdx
@@ -197,7 +197,7 @@ The signatures api will return an array of signatures, one for each available in
 ```ts
   import axios from 'axios';
 
-  const { data } = await axios.get('https://api.boost-v2.xyz/signatures', {
+  const { data } = await axios.get('/signatures', {
     params: { 
       boostId: `${chainId}:${boost.id}`, 
       txHash,


### PR DESCRIPTION
- updated Zora-Mint example to show claiming incentives using signature endpoint
- updated agora-vote example to show claiming variable incentive using signature endpoint
- updated claim-example to show claiming with the default validator using signature
- updated some stale example code