### PR TITLE
[ADHOC] fix doc typos

### DIFF
--- a/v2/boost-sdk/examples/agora-vote.mdx
+++ b/v2/boost-sdk/examples/agora-vote.mdx
@@ -29,7 +29,7 @@ import { parseUnits } from 'viem'
 import { config as wagmiConfig } from './config'
 
 // Initialize the BoostCore and BoostRegistry modules
-const registry = new BoostRegistry({ config: wagmiConfig }),
+const registry = new BoostRegistry({ config: wagmiConfig })
 const core = new BoostCore({ config: wagmiConfig })
 
 // Get the address of the BoostCore module

--- a/v2/boost-sdk/examples/template.mdx
+++ b/v2/boost-sdk/examples/template.mdx
@@ -58,7 +58,7 @@ const selectedSignature = selectors[
   'Purchased(address,address,uint256,uint256,uint256)'
 ] as Hex;
 
-// This EventAction step will define how the validator will understand who is elligible to redeem the reward.
+// This EventAction step will define how the validator will understand who is eligible to redeem the reward.
 const eventActionStep: ActionStep = {
   signature: selectedSignature,
   signatureType: SignatureType.EVENT, // We're working with an event
@@ -72,7 +72,7 @@ const eventActionStep: ActionStep = {
   },
 };
 
-// Similar to the step above, this configuration will identify the user elligible to claim based on them having taken the action triggering the `Purchased` event.
+// Similar to the step above, this configuration will identify the user eligible to claim based on them having taken the action triggering the `Purchased` event.
 const eventActionClaimant: ActionClaimant = {
   signatureType: SignatureType.EVENT,
   signature: selector, // Transfer(address,address,uint256) event signature

--- a/v2/boost-sdk/installation.mdx
+++ b/v2/boost-sdk/installation.mdx
@@ -60,7 +60,7 @@ bun add @wagmi/core @wagmi/connectors viem@2.x
 
 ### Runtime Requirements
 
-Boost SDK is optimized for modern browsers. It is compatible with the following browsers config
+Boost SDK is optimized for modern browsers. It is compatible with the following browser configurations:
 
 ```
 Chrome >= 87

--- a/v2/boost-sdk/quick-start.mdx
+++ b/v2/boost-sdk/quick-start.mdx
@@ -84,12 +84,11 @@ if(boost.allowList instanceof SimpleDenyList) {
       blockNumber: 1337n,
       blockTag: 'latest',
       dataSuffix: '0x',
-      account: privateKeyToAccount('DIFFERENT_KEY')\
+      account: privateKeyToAccount('DIFFERENT_KEY'),
       gas: 0n,
       nonce: 1,
       value: parseEther('0.01'),
       gasPrice: parseGwei('20'),
-      maxFeePerGas: parseGwei('20'),
       maxFeePerGas: parseGwei('20'),
       maxPriorityFeePerGas: parseGwei('2'),
     }

--- a/v2/boost-sdk/usage-with-react.mdx
+++ b/v2/boost-sdk/usage-with-react.mdx
@@ -122,18 +122,15 @@ export function useBoostCoreInfo() {
     initialData: {
       protocolFee: 0n,
       protocolFeeReceiver: zeroAddress,
-      claimFee: 0n,
     },
     queryFn: async () => {
-      const [protocolFee, protocolFeeReceiver, claimFee] = await Promise.all([
+      const [protocolFee, protocolFeeReceiver] = await Promise.all([
         core.protocolFee(),
         core.protocolFeeReceiver(),
-        core.claimFee(),
       ]);
       return {
         protocolFee,
         protocolFeeReceiver,
-        claimFee,
       };
     },
   });

--- a/v2/documentation/how-it-works/budget-accounts.mdx
+++ b/v2/documentation/how-it-works/budget-accounts.mdx
@@ -82,7 +82,7 @@ Click the "Create Budget" button and fill in the budget details including Displa
   You will need to make a budget account for each chain you wish to deploy funds from.
 </Note>
 
-After filling in the details, click the "Deploy Budget" button.
+After filling in the details, click the "Deploy" button.
 
 <Frame caption="Fill in the Display Name and Network details for your budget">
   <img src="/assets/budget-deploy.png" alt="Deploy Budget Button" />
@@ -111,5 +111,5 @@ From here, you can add wallet addresses and assign them either Manager or Admin 
 Authorized addresses will appear in the members list with their assigned role. Admin role holders can manage and revoke roles from this view.
 
 <Tip>
-  You can use the [Boost SDK](/v2/boost-sdk/budgets/managed/overview) to deploy and interact with budget accounts programatically.
+  You can use the [Boost SDK](/v2/boost-sdk/budgets/managed/overview) to deploy and interact with budget accounts programmatically.
 </Tip>


### PR DESCRIPTION
- Fixes a few typos and errors in the V2 docs.
- Removes any references to `claimFees` in the "working with react" examples