### PR TITLE
[BOOST-4897]: Add API section to documentation

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -42,6 +42,11 @@
       "version": "v2"
     },
     {
+      "name": "Boost API",
+      "url": "v2/boost-api",
+      "version": "v2"
+    },
+    {
       "name": "API Reference",
       "url": "/v2/api-reference",
       "openapi": "https://ponder-staging-9166160e1bc0.herokuapp.com/openapi.json",
@@ -311,6 +316,22 @@
         "v2/boost-sdk/budgets/managed/authorization",
         "v2/boost-sdk/budgets/managed/funding",
         "v2/boost-sdk/budgets/managed/retrieval"
+      ]
+    },
+    {
+      "group": "Boosts",
+      "version": "v2",
+      "pages": [
+        "v2/boost-api/fetch-boosts",
+        "v2/boost-api/boost-details",
+        "v2/boost-api/boost-activity"
+      ]
+    },
+    {
+      "group": "Claiming",
+      "version": "v2",
+      "pages": [
+        "v2/boost-api/get-signature"
       ]
     },
     {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1,7 +1,0 @@
-.text-yellow {
-  color: #FFD700;
-}
-
-.mb-0-5 {
-  margin-bottom: 0.5rem;
-}

--- a/v2/boost-api/boost-activity.mdx
+++ b/v2/boost-api/boost-activity.mdx
@@ -1,0 +1,73 @@
+---
+title: Boost Activity
+description: How to retrieve the claim history for a specific boost
+---
+
+The Boost API allows you to fetch the claim history for a specific boost through the [GET /boosts/:id/activity endpoint](/v2/api-reference/boosts/get-boost-activity).
+
+## Basic Usage
+
+Fetch the activity history for a specific boost:
+
+```typescript
+const boostId = '8453:12';
+const response = await fetch(
+  `https://ponder-staging-9166160e1bc0.herokuapp.com/boosts/${boostId}/activity`
+);
+const { activityEvents } = await response.json();
+```
+
+<Tip>
+  For complete API details including all available parameters and response fields, see the [API Reference](/v2/api-reference/boosts/get-boost-activity).
+</Tip>
+
+## Response Structure
+
+The response includes:
+- `activityEvents`: Array of claim events
+- `totalActivityCount`: Total number of claims made on this boost
+
+```typescript
+// Example response structure
+{
+    "activityEvents": [
+        {
+            "claimant": "0xB0057...", // Address that claimed the incentive
+            "blockTimestamp": "1731373464",
+            "txHash": "0x2dfc8f...", // Transaction hash of the claim
+            "incentives": [
+                {
+                    "type": "ERC20Incentive",
+                    "asset": "0xf3b2d...", // Token address
+                    "limit": "10",
+                    "reward": "500000000000000000",
+                    "strategy": 0,
+                    "totalAmountClaimed": "",
+                    "totalClaims": "1"
+                }
+            ]
+        }
+    ],
+    "totalActivityCount": 1
+}
+```
+
+## Pagination
+
+<Note>
+  The API returns an empty array when there are no more activity events to fetch.
+</Note>
+
+The endpoint supports pagination similar to the boost list endpoint:
+
+```typescript
+const params = new URLSearchParams({
+  page: '1',
+  pageSize: '20'  // Adjust based on your needs (max 100)
+});
+
+const response = await fetch(
+  `https://ponder-staging-9166160e1bc0.herokuapp.com/boosts/${boostId}/activity?${params.toString()}`
+);
+const { activityEvents } = await response.json();
+```

--- a/v2/boost-api/boost-details.mdx
+++ b/v2/boost-api/boost-details.mdx
@@ -1,0 +1,26 @@
+---
+title: Boost Details
+description: How to retrieve a single boost by its ID
+---
+
+The Boost API allows you to fetch a single boost through the [GET /boosts/:id endpoint](/v2/api-reference/boosts/get-boost-details).
+
+## Basic Usage
+
+<Note>
+  The `id` parameter is a combination of the chainId and boostId (e.g., `8453:12`).
+</Note>
+
+Fetch a specific boost using its ID:
+
+```typescript
+const boostId = '8453:12';
+const response = await fetch(
+  `https://ponder-staging-9166160e1bc0.herokuapp.com/boosts/${boostId}`
+);
+const { boost } = await response.json();
+```
+
+<Tip>
+  For complete API details including all available parameters and response fields, see the [API Reference](/v2/api-reference/boosts/get-boost-details).
+</Tip>

--- a/v2/boost-api/fetch-boosts.mdx
+++ b/v2/boost-api/fetch-boosts.mdx
@@ -1,0 +1,87 @@
+---
+title: Fetch Boosts
+description: How to query for Boosts using various filters
+---
+
+The Boost API allows you to fetch and filter boosts through the [GET /boosts endpoint](/v2/api-reference/boosts/get-boosts).
+
+## Basic Usage
+
+Fetch all boosts with no filters:
+
+```typescript
+const response = await fetch(
+  'https://ponder-staging-9166160e1bc0.herokuapp.com/boosts'
+);
+const { boosts } = await response.json();
+```
+
+<Tip>
+  For complete API details including all available parameters and response fields, see the [API Reference](/v2/api-reference/boosts/get-boosts).
+</Tip>
+
+
+## Filtering Boosts
+
+<Note>
+  The owner represents the address that initiated the boost deployment through a budget account.
+</Note>
+
+You can filter boosts using various parameters:
+- `chainId`: Filter by specific blockchain network
+- `owner`: Filter by the address that deployed the boost
+- `budgetAddress`: Filter by specific budget account
+
+Example using multiple filters:
+
+```typescript
+const params = new URLSearchParams({
+  owner: '0x1234...',
+  chainId: '8453', // Base
+  budgetAddress: '0x5678...'
+});
+
+const response = await fetch(
+  `https://ponder-staging-9166160e1bc0.herokuapp.com/boosts?${params.toString()}`
+);
+const { boosts } = await response.json();
+```
+
+## Pagination
+
+<Note>
+  The maximum page size is 100 items.
+</Note>
+
+The endpoint uses simple pagination through `page` and `pageSize` parameters. Here's how to fetch all boosts:
+
+```typescript
+async function fetchAllBoosts() {
+  const pageSize = 20;  // Adjust based on your needs (max 100)
+  let currentPage = 1;
+  let allBoosts = [];
+  
+  while (true) {
+    const params = new URLSearchParams({
+      page: currentPage.toString(),
+      pageSize: pageSize.toString()
+    });
+
+    const response = await fetch(
+      `https://ponder-staging-9166160e1bc0.herokuapp.com/boosts?${params.toString()}`
+    );
+    
+    const { boosts } = await response.json();
+    
+    // When the API returns an empty boosts array, we've fetched all boosts
+    if (!boosts || boosts.length === 0) {
+      break;
+    }
+    
+    allBoosts = [...allBoosts, ...boosts];
+    currentPage++;
+  }
+
+  return allBoosts;
+}
+```

--- a/v2/boost-api/fetch-boosts.mdx
+++ b/v2/boost-api/fetch-boosts.mdx
@@ -3,6 +3,8 @@ title: Fetch Boosts
 description: How to query for Boosts using various filters
 ---
 
+[//]: #(TODO: Update the API endpoint to prod URL when it's live)
+
 The Boost API allows you to fetch and filter boosts through the [GET /boosts endpoint](/v2/api-reference/boosts/get-boosts).
 
 ## Basic Usage

--- a/v2/boost-api/get-signature.mdx
+++ b/v2/boost-api/get-signature.mdx
@@ -1,0 +1,62 @@
+---
+title: Get Claim Signature
+description: How to retrieve a signature required for claiming boost incentives
+---
+
+The Boost API allows you to get the required signature for claiming boost incentives using the [GET /signatures endpoint](/v2/api-reference/signatures/get-signature).
+
+## Basic Usage
+
+Fetch a signature for claiming a boost:
+
+```typescript
+const params = new URLSearchParams({
+  txHash: '0x2dfc8f4f24b1a3a7ee73ea13b8a20a63fe7457d1c96b95178d3ea4126b6bf5ad',
+  boostId: '8453:12'
+});
+
+const response = await fetch(
+  `https://ponder-staging-9166160e1bc0.herokuapp.com/signatures?${params.toString()}`
+);
+const { signature, claimant, incentiveId } = await response.json();
+```
+
+<Tip>
+  For complete API details including all available parameters and response fields, see the [API Reference](/v2/api-reference/boosts/validate-&-sign-data-for-a-claim).
+</Tip>
+
+## Required Parameters
+
+<Note>
+  The signature endpoint validates that the transaction meets the boost's requirements before returning a signature.
+</Note>
+
+- `txHash`: The transaction hash that completed the boost's required action
+- `boostId`: The ID of the boost (format: `chainId:boostNumber`)
+- `claimData`: (Optional) Additional data required for variable incentive types
+
+```typescript
+// Example response structure from the API
+{
+    "signature": "0x...",   // Signature for verification
+    "claimant": "0x...",    // Address eligible to claim
+    "incentiveId": 0        // ID of the claimable incentive
+}
+```
+
+## Using the Signature
+
+Once you have the signature from the API, you can use it with the following SDK methods to claim your boost:
+- [`BoostCore.claimIncentive`](/v2/boost-sdk/boost-core/claim-incentive#claimincentive) - Claim for the transaction sender
+- [`BoostCore.claimIncentiveFor`](/v2/boost-sdk/boost-core/claim-incentive#claimincentivefor) - Claim on behalf of another address
+
+<Frame>
+  <Card
+    title="Complete Claim Example"
+    href="/v2/boost-sdk/examples/claim-example"
+    icon="arrow-right"
+    horizontal
+  >
+    See our SDK documentation for a complete example of claiming a boost with the returned signature.
+  </Card> 
+</Frame>

--- a/v2/boost-sdk/examples/claim-example.mdx
+++ b/v2/boost-sdk/examples/claim-example.mdx
@@ -11,7 +11,7 @@ To claim a reward from a Boost, you'll need to follow these general steps:
 3. Execute the claim transaction
 
 This process will differ depending on if you have set up your own validator or are using the default validator.
-If using the default validator, you will need to call the boost's `/signatures` endpoint to generate the signature payload, 
+If using the default validator, you will need to call the [Boost API `/signatures` endpoint](/v2/boost-api/get-signature) to generate the signature payload, 
 otherwise you will need to build the payload yourself.
 
 <Tip>


### PR DESCRIPTION
- Adds a API tab to complement the API reference tab. Shows examples for all boost routes and claim signature route.
- Will add in other routes at later date.
- Removes unused styles.css file (according to the docs, custom css costs an additional $100/month 😬)

This should complete the ticket https://linear.app/rh-app/issue/BOOST-4897/add-top-level-section-for-high-level-protocol-design